### PR TITLE
Support for image ids

### DIFF
--- a/cgit-wp-schema.php
+++ b/cgit-wp-schema.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Castlegate IT WP Schema
  * Plugin URI:   https://github.com/castlegateit/cgit-wp-schema
  * Description:  Basic schema.org integration.
- * Version:      1.2.0
+ * Version:      1.2.1
  * Requires PHP: 8.2
  * Author:       Castlegate IT
  * Author URI:   https://www.castlegateit.co.uk/

--- a/classes/Schema/Organization.php
+++ b/classes/Schema/Organization.php
@@ -140,8 +140,20 @@ class Organization extends Schema
                 continue;
             }
 
+            $image_url = null;
             $schema = new ImageObject;
-            $schema->set('url', $image['url']);
+
+            if (is_numeric($image) && (int) $image > 0) {
+                $image_url = wp_get_attachment_url((int)$image);
+            } elseif (is_array($image) && array_key_exists('url', $image)) {
+                $image_url = $image['url'];
+            }
+
+            if (!$image_url || filter_var($image_url, FILTER_VALIDATE_URL) === false) {
+                continue;
+            }
+
+            $schema->set('url', $image_url);
             $this->set($key, $schema->export());
         }
     }


### PR DESCRIPTION
This update adds image ID support to the `updateImageFields()` method.

The current version of this method attempts to extract the image URL from an array containing various bits of data about the image fetched via ACF's `get_field()` function. But if custom fields on the site are globally configured to return IDs instead of arrays, this method fails to extract the URL and this results in the following warning.

`PHP Warning:  Trying to access array offset on value of type int`